### PR TITLE
added new parameter windowSize for Spectrogram

### DIFF
--- a/src/Spectrogram.cpp
+++ b/src/Spectrogram.cpp
@@ -9,9 +9,9 @@ Spectrogram::Spectrogram()
     this->currIndex  = 0;
 };
 
-Spectrogram::Spectrogram(const uint16_t numWindows)
+Spectrogram::Spectrogram(const uint16_t numWindows, int windowSize)
 {
-    uint16_t numBins = WINDOW_SIZE >> 1;
+    uint16_t numBins = windowSize >> 1;
     this->buffer     = new float[numWindows * numBins];
     this->numWindows = numWindows;
     this->numBins    = numBins;

--- a/src/Spectrogram.h
+++ b/src/Spectrogram.h
@@ -32,12 +32,12 @@ public:
      *
      * Allocates a buffer to hold data for the specified number of windows,
      * with the specified number of frequency bins in each window. Each window
-     * will contain a number of frequency bins equal half the WINDOW_SIZE.
+     * will contain a number of frequency bins equal half the windowSize.
      * Initializes the current index to 0.
      *
      * @param numWindows The number of time windows the Spectrogram holds.
      */
-    Spectrogram(const uint16_t numWindows);
+    Spectrogram(const uint16_t numWindows, int windowSize);
 
     ~Spectrogram();
 


### PR DESCRIPTION
This is for the issue surrounding the inconvenience that will come up when implementing the overlapping FFT windows. It will ensure the spectrogram object will be able to be setup with various window sizes.