### PR TITLE
feat: add clearModules method to ModuleGroup

### DIFF
--- a/src/ModuleGroup.cpp
+++ b/src/ModuleGroup.cpp
@@ -28,6 +28,11 @@ void ModuleGroup::addModule(AnalysisModule* module, int lowerFreq, int upperFreq
     this->modules.push_back(module);
 }
 
+void ModuleGroup::clearModules()
+{
+  this->modules.clear();
+}
+
 void ModuleGroup::runAnalysis()
 {
     for (AnalysisModule* module : this->modules) {

--- a/src/ModuleGroup.cpp
+++ b/src/ModuleGroup.cpp
@@ -28,11 +28,6 @@ void ModuleGroup::addModule(AnalysisModule* module, int lowerFreq, int upperFreq
     this->modules.push_back(module);
 }
 
-void ModuleGroup::clearModules()
-{
-  this->modules.clear();
-}
-
 void ModuleGroup::runAnalysis()
 {
     for (AnalysisModule* module : this->modules) {

--- a/src/ModuleGroup.h
+++ b/src/ModuleGroup.h
@@ -78,6 +78,11 @@ public:
         int lowerFreq, int upperFreq);
 
     /**
+     * Clear existing analysis modules.
+     */
+    void clearModules();
+
+    /**
      * Run the analysis function for all modules in the group.
      */
     void runAnalysis();

--- a/src/ModuleGroup.h
+++ b/src/ModuleGroup.h
@@ -80,7 +80,7 @@ public:
     /**
      * Clear existing analysis modules.
      */
-    void clearModules();
+    void clearModules() { this->modules.clear(); }
 
     /**
      * Run the analysis function for all modules in the group.


### PR DESCRIPTION
Adds method to clear current analysis modules from a module group. Necessary for dynamic configuration of audio analysis - will need to clear and recreate modules if a user adjusts certain analysis parameters while analysis is running.